### PR TITLE
add search domain for split-dns setups

### DIFF
--- a/templates/config.ovpn.tpl
+++ b/templates/config.ovpn.tpl
@@ -8,6 +8,7 @@ nobind
 persist-key
 persist-tun
 remote-cert-tls server
+dhcp-option DOMAIN-SEARCH 3sca.net
 cipher AES-256-GCM
 verb 3
 reneg-sec 0


### PR DESCRIPTION
This particularly helps with DNS routers that filter private IP ranges
from responces of public DNS servers.

It is also possible to be done on server side with the option:
```
push "dhcp-option DOMAIN-SEARCH <SEARCH_DOMAIN>"
```

Note that this is an openvpn client 2.x option. For 3.x not sure this is supported yet. see https://community.openvpn.net/openvpn/ticket/1209

But in Fedora 36 I see OpenVPN 2.5 being used.

The option is described in `man openvpn`.

I COULD NOT TEST THIS AS I'M USING Network Manager!!!