### PR TITLE
fix: use readyz handler for /readyz

### DIFF
--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -193,7 +193,7 @@ func start(vc vault.AuthenticatedClient) {
 	mux.HandleFunc("/revoke/{user}", revokeUserHandler(vc)).Methods(http.MethodPost)
 	mux.HandleFunc("/users", listUsersHandler(vc)).Methods(http.MethodGet)
 	mux.HandleFunc("/healthz", healthzHandler(vc)).Methods(http.MethodGet)
-	mux.HandleFunc("/readyz", healthzHandler(vc)).Methods(http.MethodGet)
+	mux.HandleFunc("/readyz", readyzHandler(vc)).Methods(http.MethodGet)
 	// Add a logging middleware
 	loggedRouter := handlers.CombinedLoggingHandler(os.Stdout, mux)
 


### PR DESCRIPTION
This pull request includes a small but important change to the `cmd/app/server.go` file. The change ensures that the `/readyz` endpoint uses the correct handler.

* [`cmd/app/server.go`](diffhunk://#diff-7a12f7ace42b036191ea1246ed0b0564c6b259bfcb109d8d5180ec7cc9ead683L196-R196): Changed the handler for the `/readyz` endpoint from `healthzHandler` to `readyzHandler` to ensure the correct functionality.

/kind bug
/priority important-soon
/assign